### PR TITLE
WIP fix: add an end-to-end unit test to demonstrate a bug with incomplete response bodies

### DIFF
--- a/e2e_test.go
+++ b/e2e_test.go
@@ -1,0 +1,37 @@
+package agent_test
+
+import (
+	"io/ioutil"
+	"net/http"
+	"os"
+	"testing"
+
+	bearer "github.com/bearer/go-agent"
+)
+
+func TestE2E(t *testing.T) {
+	secret := os.Getenv("BEARER_SECRETKEY")
+	if secret == "" {
+		t.Skip("TestE2E requires a valid $BEARER_SECRETKEY")
+	}
+	agent := bearer.New(secret)
+	defer agent.Close()
+
+	transport := agent.Decorate(&http.Transport{})
+	client := http.Client{Transport: transport}
+
+	resp, err := client.Get("https://httpbin.org/bytes/1000")
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("cannot read body: %v", err)
+	}
+
+	if len(body) != 1000 {
+		t.Errorf("invalid response length; expected %d, got %d.", 1000, len(body))
+	}
+}


### PR DESCRIPTION
https://app.bearer.sh/log-sharing/TG9nRW50cnktMjI2MzQwNzc=?token=12bd60b5-d6c5-49e8-896e-7ed158ec0969

![Screenshot - Manfred 2020-10-30 at 19 06 17](https://user-images.githubusercontent.com/94029/97741443-0349d200-1ae3-11eb-9333-1301e3fd6c9a.png)

If I return the response and error here (https://github.com/Bearer/go-agent/blob/master/interception/round_tripper.go#L214), everything is okay; then, the body returned to the client is limited to the first 512bytes

---

the bug only happens when the bearer secret is valid; if you put an invalid bearer secret, then, no error; so probably a bug introduced by the configuration received from the bearer servers

---

```console
foo@bar$> BEARER_SECRETKEY=VALID_KEY go test -v -run TestE2E
=== RUN   TestE2E
    e2e_test.go:35: invalid response length; expected 1000, got 512.
--- FAIL: TestE2E (0.65s)
FAIL
exit status 1
FAIL    github.com/bearer/go-agent      0.664s
foo@bar$> BEARER_SECRETKEY=INVALID_KEY go test -v -run TestE2E
=== RUN   TestE2E
{"level":"warn","message":"failed remote config from Bearer: the Bearer platform rejected the config fetch"}
2020/10/30 19:11:42 agent disabled
--- PASS: TestE2E (0.48s)
PASS
ok      github.com/bearer/go-agent      0.493s
```